### PR TITLE
task(2): Add parser rules reference to LIL-INTDEV-AGENTS.md (if exists)

### DIFF
--- a/LIL-INTDEV-AGENTS.md
+++ b/LIL-INTDEV-AGENTS.md
@@ -1,0 +1,10 @@
+# LIL-INTDEV Agent Guidelines
+
+## URL / Query Parser Rules
+
+The source of truth for all URL and query-parameter parsing behavior is [`SCENARIOS.md`](./SCENARIOS.md).
+
+- **v1 acceptance contract** — `SCENARIOS.md` sections 1–13 define every valid and invalid input for the `equity=` query parser. Any behavior not listed there is undefined and must be rejected.
+- **End-to-end scenarios** — `SCENARIOS.md` sections A1–A23 cover the full user experience including benchmarks, time ranges, error states, and auth-free operation.
+- **When adding or changing parser behavior**, update `SCENARIOS.md` first, then update tests to match. Tests must cover every scenario listed in the document.
+- **When tests fail**, check `SCENARIOS.md` to determine whether the test or the implementation is wrong. The scenarios file is the contract — implementation follows it, not the other way around.


### PR DESCRIPTION
## Task 2 from plan #13

**Plan:** SCENARIOS.md: codify strict v1 URL/query parser acceptance contract
**Goal:** Define concrete, testable scenarios for the v1 query parser so URL behavior is strict, debuggable, and forward-compatible with weights v2.

### Changes
1 file changed, 10 insertions(+)

**Files changed (1):**
- `LIL-INTDEV-AGENTS.md`

**Tests:** None found

---
Part of #13