### PR TITLE
task(4): Implement market data fetch layer + caching

### DIFF
--- a/app/api/benchmark/route.ts
+++ b/app/api/benchmark/route.ts
@@ -1,0 +1,177 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { VALID_BENCHMARKS, VALID_RANGES } from '@common/types';
+import type { PricePoint, RangeValue, SeriesData } from '@common/types';
+
+const YAHOO_CHART_URL = 'https://query1.finance.yahoo.com/v8/finance/chart';
+
+const BENCHMARK_TO_YAHOO: Record<string, string> = {
+  gold: 'GC=F',
+  eth: 'ETH-USD',
+};
+
+const BENCHMARK_DISPLAY: Record<string, string> = {
+  gold: 'Gold',
+  eth: 'ETH',
+  usd: 'USD',
+};
+
+const RANGE_TO_YAHOO: Record<RangeValue, { range: string; interval: string }> = {
+  '1m': { range: '1mo', interval: '1d' },
+  '3m': { range: '3mo', interval: '1d' },
+  '6m': { range: '6mo', interval: '1d' },
+  ytd: { range: 'ytd', interval: '1d' },
+  '1y': { range: '1y', interval: '1d' },
+  '3y': { range: '3y', interval: '1wk' },
+  '5y': { range: '5y', interval: '1wk' },
+  max: { range: 'max', interval: '1mo' },
+};
+
+function parseYahooChart(data: any, displayName: string): PricePoint[] {
+  const result = data?.chart?.result?.[0];
+  if (!result) {
+    throw new Error(`No data found for benchmark: ${displayName}`);
+  }
+
+  const timestamps: number[] = result.timestamp ?? [];
+  const closes: (number | null)[] = result.indicators?.quote?.[0]?.close ?? [];
+
+  const points: PricePoint[] = [];
+  for (let i = 0; i < timestamps.length; i++) {
+    const close = closes[i];
+    if (close == null || !isFinite(close)) continue;
+
+    const date = new Date(timestamps[i] * 1000).toISOString().split('T')[0];
+    points.push({ date, close });
+  }
+
+  if (points.length === 0) {
+    throw new Error(`No data found for benchmark: ${displayName}`);
+  }
+
+  return points;
+}
+
+function generateUsdBaseline(range: RangeValue): PricePoint[] {
+  const now = new Date();
+  const start = new Date();
+
+  switch (range) {
+    case '1m':
+      start.setMonth(start.getMonth() - 1);
+      break;
+    case '3m':
+      start.setMonth(start.getMonth() - 3);
+      break;
+    case '6m':
+      start.setMonth(start.getMonth() - 6);
+      break;
+    case 'ytd':
+      start.setMonth(0, 1);
+      break;
+    case '1y':
+      start.setFullYear(start.getFullYear() - 1);
+      break;
+    case '3y':
+      start.setFullYear(start.getFullYear() - 3);
+      break;
+    case '5y':
+      start.setFullYear(start.getFullYear() - 5);
+      break;
+    case 'max':
+      start.setFullYear(start.getFullYear() - 20);
+      break;
+  }
+
+  const points: PricePoint[] = [];
+  const current = new Date(start);
+  while (current <= now) {
+    points.push({
+      date: current.toISOString().split('T')[0],
+      close: 1,
+    });
+    current.setDate(current.getDate() + 1);
+  }
+
+  return points;
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const benchmarks = searchParams.get('benchmarks');
+  const range = (searchParams.get('range') ?? '1y') as RangeValue;
+
+  if (!benchmarks) {
+    return NextResponse.json({ error: 'Missing benchmarks parameter' }, { status: 400 });
+  }
+
+  if (!VALID_RANGES.includes(range)) {
+    return NextResponse.json({ error: `Invalid range: ${range}. Valid ranges: ${VALID_RANGES.join(', ')}` }, { status: 400 });
+  }
+
+  const benchmarkList = benchmarks
+    .split('|')
+    .map((b) => b.trim().toLowerCase())
+    .filter(Boolean);
+
+  if (benchmarkList.length === 0) {
+    return NextResponse.json({ error: 'No valid benchmarks provided' }, { status: 400 });
+  }
+
+  for (const b of benchmarkList) {
+    if (!VALID_BENCHMARKS.includes(b as any)) {
+      return NextResponse.json({ error: `Unknown benchmark: ${b}. Valid benchmarks: ${VALID_BENCHMARKS.join(', ')}` }, { status: 400 });
+    }
+  }
+
+  const yahooParams = RANGE_TO_YAHOO[range];
+
+  try {
+    const results: SeriesData[] = [];
+
+    for (const benchmark of benchmarkList) {
+      const displayName = BENCHMARK_DISPLAY[benchmark];
+
+      if (benchmark === 'usd') {
+        results.push({
+          ticker: 'USD',
+          points: generateUsdBaseline(range),
+          source: 'Cash baseline',
+        });
+        continue;
+      }
+
+      const yahooSymbol = BENCHMARK_TO_YAHOO[benchmark];
+      const url = `${YAHOO_CHART_URL}/${encodeURIComponent(yahooSymbol)}?range=${yahooParams.range}&interval=${yahooParams.interval}`;
+
+      const res = await fetch(url, {
+        next: { revalidate: 3600 },
+        headers: {
+          'User-Agent': 'Mozilla/5.0',
+        },
+      });
+
+      if (res.status === 429) {
+        return NextResponse.json({ error: 'Data temporarily unavailable. Please try again.' }, { status: 429 });
+      }
+
+      if (!res.ok) {
+        return NextResponse.json({ error: 'Data temporarily unavailable. Please try again.' }, { status: 502 });
+      }
+
+      const data = await res.json();
+      const points = parseYahooChart(data, displayName);
+
+      results.push({
+        ticker: displayName,
+        points,
+        source: 'Yahoo Finance',
+      });
+    }
+
+    return NextResponse.json({ series: results });
+  } catch (error: any) {
+    const message = error?.message ?? 'Data temporarily unavailable. Please try again.';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/market-data/route.ts
+++ b/app/api/market-data/route.ts
@@ -1,0 +1,112 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { VALID_RANGES } from '@common/types';
+import type { PricePoint, RangeValue, SeriesData } from '@common/types';
+
+const YAHOO_CHART_URL = 'https://query1.finance.yahoo.com/v8/finance/chart';
+
+const RANGE_TO_YAHOO: Record<RangeValue, { range: string; interval: string }> = {
+  '1m': { range: '1mo', interval: '1d' },
+  '3m': { range: '3mo', interval: '1d' },
+  '6m': { range: '6mo', interval: '1d' },
+  ytd: { range: 'ytd', interval: '1d' },
+  '1y': { range: '1y', interval: '1d' },
+  '3y': { range: '3y', interval: '1wk' },
+  '5y': { range: '5y', interval: '1wk' },
+  max: { range: 'max', interval: '1mo' },
+};
+
+function parseYahooChart(data: any, ticker: string): SeriesData {
+  const result = data?.chart?.result?.[0];
+  if (!result) {
+    throw new Error(`No data found for ticker: ${ticker}`);
+  }
+
+  const timestamps: number[] = result.timestamp ?? [];
+  const closes: (number | null)[] = result.indicators?.quote?.[0]?.close ?? [];
+
+  const points: PricePoint[] = [];
+  for (let i = 0; i < timestamps.length; i++) {
+    const close = closes[i];
+    if (close == null || !isFinite(close)) continue;
+
+    const date = new Date(timestamps[i] * 1000).toISOString().split('T')[0];
+    points.push({ date, close });
+  }
+
+  if (points.length === 0) {
+    throw new Error(`No data found for ticker: ${ticker}`);
+  }
+
+  return {
+    ticker: ticker.toUpperCase(),
+    points,
+    source: 'Yahoo Finance',
+  };
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const tickers = searchParams.get('tickers');
+  const range = (searchParams.get('range') ?? '1y') as RangeValue;
+
+  if (!tickers) {
+    return NextResponse.json({ error: 'Missing tickers parameter' }, { status: 400 });
+  }
+
+  if (!VALID_RANGES.includes(range)) {
+    return NextResponse.json({ error: `Invalid range: ${range}. Valid ranges: ${VALID_RANGES.join(', ')}` }, { status: 400 });
+  }
+
+  const tickerList = tickers
+    .split(',')
+    .map((t) => t.trim().toUpperCase())
+    .filter(Boolean);
+
+  if (tickerList.length === 0) {
+    return NextResponse.json({ error: 'No valid tickers provided' }, { status: 400 });
+  }
+
+  const yahooParams = RANGE_TO_YAHOO[range];
+
+  try {
+    const results: SeriesData[] = [];
+
+    for (const ticker of tickerList) {
+      const url = `${YAHOO_CHART_URL}/${encodeURIComponent(ticker)}?range=${yahooParams.range}&interval=${yahooParams.interval}&events=div`;
+
+      const res = await fetch(url, {
+        next: { revalidate: 3600 },
+        headers: {
+          'User-Agent': 'Mozilla/5.0',
+        },
+      });
+
+      if (res.status === 404) {
+        return NextResponse.json({ error: `No data found for ticker: ${ticker}` }, { status: 404 });
+      }
+
+      if (res.status === 429) {
+        return NextResponse.json({ error: 'Data temporarily unavailable. Please try again.' }, { status: 429 });
+      }
+
+      if (!res.ok) {
+        return NextResponse.json({ error: `Data temporarily unavailable. Please try again.` }, { status: 502 });
+      }
+
+      const data = await res.json();
+      const series = parseYahooChart(data, ticker);
+      results.push(series);
+    }
+
+    return NextResponse.json({ series: results });
+  } catch (error: any) {
+    const message = error?.message ?? 'Data temporarily unavailable. Please try again.';
+
+    if (message.startsWith('No data found for ticker:')) {
+      return NextResponse.json({ error: message }, { status: 404 });
+    }
+
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/common/market-data.ts
+++ b/common/market-data.ts
@@ -1,0 +1,60 @@
+import type { SeriesData, RangeValue, BenchmarkValue } from '@common/types';
+import { VALID_RANGES, VALID_BENCHMARKS } from '@common/types';
+
+export interface NormalizedPoint {
+  date: string;
+  value: number;
+}
+
+export interface NormalizedSeries {
+  ticker: string;
+  points: NormalizedPoint[];
+  source: string;
+}
+
+/**
+ * Normalizes a series so the first data point = 0% and subsequent points
+ * represent % change from that start. E.g. a value of 15.5 means +15.5%.
+ */
+export function normalizeSeries(series: SeriesData): NormalizedSeries {
+  if (series.points.length === 0) {
+    return { ticker: series.ticker, points: [], source: series.source };
+  }
+
+  const startPrice = series.points[0].close;
+
+  return {
+    ticker: series.ticker,
+    source: series.source,
+    points: series.points.map((p) => ({
+      date: p.date,
+      value: ((p.close - startPrice) / startPrice) * 100,
+    })),
+  };
+}
+
+/**
+ * Normalizes multiple series and aligns them to a common date range.
+ * Only dates present in ALL series are included.
+ */
+export function normalizeAllSeries(allSeries: SeriesData[]): NormalizedSeries[] {
+  if (allSeries.length === 0) return [];
+
+  const normalized = allSeries.map(normalizeSeries);
+
+  const dateSets = normalized.map((s) => new Set(s.points.map((p) => p.date)));
+  const commonDates = new Set(Array.from(dateSets[0]).filter((date) => dateSets.every((set) => set.has(date))));
+
+  return normalized.map((s) => ({
+    ...s,
+    points: s.points.filter((p) => commonDates.has(p.date)),
+  }));
+}
+
+export function isValidRange(value: string): value is RangeValue {
+  return VALID_RANGES.includes(value as RangeValue);
+}
+
+export function isValidBenchmark(value: string): value is BenchmarkValue {
+  return VALID_BENCHMARKS.includes(value as BenchmarkValue);
+}

--- a/common/types.ts
+++ b/common/types.ts
@@ -1,0 +1,17 @@
+export interface PricePoint {
+  date: string;
+  close: number;
+}
+
+export interface SeriesData {
+  ticker: string;
+  points: PricePoint[];
+  source: string;
+}
+
+export type RangeValue = '1m' | '3m' | '6m' | 'ytd' | '1y' | '3y' | '5y' | 'max';
+
+export const VALID_RANGES: RangeValue[] = ['1m', '3m', '6m', 'ytd', '1y', '3y', '5y', 'max'];
+
+export const VALID_BENCHMARKS = ['gold', 'eth', 'usd'] as const;
+export type BenchmarkValue = (typeof VALID_BENCHMARKS)[number];


### PR DESCRIPTION
## Task 4 from plan #1

**Plan:** Plan: Portfolio vs benchmark comparer (query param equities + commodity/fiat)
**Goal:** Ship a small web app that accepts `?equity=tsmc,aapl,msft&benchmark=gold|eth|usd` and displays comparable performance over time with clear assumptions.

### Changes
4 files changed, 366 insertions(+)

**Files changed (4):**
- `app/api/benchmark/route.ts`
- `app/api/market-data/route.ts`
- `common/market-data.ts`
- `common/types.ts`

**Tests:** None found

---
Part of #1