### PR TITLE
task(1): Create/refresh SCENARIOS.md for v1 query contract (strict equal-weight) + error semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ All application state lives in the URL. Copy and share any URL to reproduce the 
 
 | Parameter   | Required | Format                        | Default | Description                                      |
 | ----------- | -------- | ----------------------------- | ------- | ------------------------------------------------ |
-| `equity`    | Yes      | Comma-separated ticker list   | —       | Up to 10 equity tickers (e.g. `AAPL,MSFT,TSMC`) |
+| `equity`    | Yes      | Comma-separated ticker list   | —       | Up to 20 tickers per portfolio (e.g. `AAPL,MSFT,TSMC`). Repeat for multi-portfolio (max 5). |
 | `benchmark` | No       | Pipe-separated benchmark list | —       | One or more benchmarks: `gold`, `eth`, `usd`     |
 | `range`     | No       | Time range code               | `1y`    | `1m`, `3m`, `6m`, `ytd`, `1y`, `3y`, `5y`, `max` |
 
@@ -49,6 +49,13 @@ All application state lives in the URL. Copy and share any URL to reproduce the 
 ```
 /?equity=AAPL,GOOG
 ```
+
+**Multi-portfolio comparison:**
+```
+/?equity=AAPL,MSFT&equity=GOOG,TSLA&benchmark=gold
+```
+
+See [SCENARIOS.md](./SCENARIOS.md) for the full v1 query contract, validation rules, and error semantics.
 
 ### Benchmarks
 

--- a/SCENARIOS.md
+++ b/SCENARIOS.md
@@ -286,6 +286,8 @@ Then an error is returned with message: "Invalid character '|' in ticker 'AAPL|M
 
 ## 8. Invalid Ticker Format
 
+`MAX_TICKER_LENGTH = 10`
+
 ### 8.1 Numeric-only ticker is rejected
 
 ```


### PR DESCRIPTION
## Task 1 from plan #29

**Plan:** Plan: v1 auth-free portfolio-compare MVP (strict parser + scenarios + agent docs), with v2 weights reserved
**Goal:** Ship an auth-free v1 portfolio-vs-benchmark compare app with a strict, test-backed query contract (equal-weight only), plus clear agent/scenario documentation; keep v2 weights explicitly reserved and specified for follow-up.

### Changes
2 files changed, 10 insertions(+), 1 deletion(-)

**Files changed (2):**
- `README.md`
- `SCENARIOS.md`

**Tests:** None found

---
Part of #29