### PR TITLE
task(4): Add unit tests for parser + scenario coverage (happy paths + failure modes)

### DIFF
--- a/common/parser.test.ts
+++ b/common/parser.test.ts
@@ -1,0 +1,539 @@
+// Unit tests for the v1 query parser — maps 1:1 to SCENARIOS.md sections 1–13
+// Each test references the scenario ID it covers.
+
+import { describe, it, expect } from 'vitest';
+import { parsePortfolios, MAX_PORTFOLIOS, MAX_TICKERS_PER_PORTFOLIO, MAX_TICKER_LENGTH } from './parser';
+
+function parse(query: string) {
+  return parsePortfolios(new URLSearchParams(query));
+}
+
+// ─── §1. Happy Path — Valid Input ────────────────────────────────────────────
+
+describe('§1 Happy Path — Valid Input', () => {
+  it('1.1 Single ticker', () => {
+    const result = parse('equity=AAPL');
+    expect(result).toEqual({ ok: true, portfolios: [['AAPL']] });
+  });
+
+  it('1.2 Multiple tickers (comma-separated)', () => {
+    const result = parse('equity=AAPL,MSFT,GOOG');
+    expect(result).toEqual({ ok: true, portfolios: [['AAPL', 'MSFT', 'GOOG']] });
+  });
+
+  it('1.3 Ordering is preserved', () => {
+    const result = parse('equity=GOOG,AAPL,MSFT');
+    expect(result).toEqual({ ok: true, portfolios: [['GOOG', 'AAPL', 'MSFT']] });
+  });
+
+  it('1.4 Multiple portfolios via repeated equity params', () => {
+    const result = parse('equity=AAPL,MSFT&equity=GOOG,TSLA');
+    expect(result).toEqual({
+      ok: true,
+      portfolios: [
+        ['AAPL', 'MSFT'],
+        ['GOOG', 'TSLA'],
+      ],
+    });
+  });
+
+  it('1.5 Single ticker per portfolio, multiple portfolios', () => {
+    const result = parse('equity=AAPL&equity=MSFT&equity=GOOG');
+    expect(result).toEqual({
+      ok: true,
+      portfolios: [['AAPL'], ['MSFT'], ['GOOG']],
+    });
+  });
+});
+
+// ─── §2. Ticker Normalization ────────────────────────────────────────────────
+
+describe('§2 Ticker Normalization', () => {
+  it('2.1 Lowercase input is uppercased', () => {
+    const result = parse('equity=aapl,msft');
+    expect(result).toEqual({ ok: true, portfolios: [['AAPL', 'MSFT']] });
+  });
+
+  it('2.2 Mixed-case input is uppercased', () => {
+    const result = parse('equity=Aapl,mSfT,gOOg');
+    expect(result).toEqual({ ok: true, portfolios: [['AAPL', 'MSFT', 'GOOG']] });
+  });
+});
+
+// ─── §3. Whitespace Handling ─────────────────────────────────────────────────
+
+describe('§3 Whitespace Handling', () => {
+  it('3.1 Leading/trailing whitespace on tokens is trimmed', () => {
+    const result = parse('equity= AAPL , MSFT ');
+    expect(result).toEqual({ ok: true, portfolios: [['AAPL', 'MSFT']] });
+  });
+
+  it('3.2 Whitespace-only token between commas is treated as empty token', () => {
+    const result = parse('equity=AAPL, ,MSFT');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('Empty ticker at position 2');
+    }
+  });
+
+  it('3.3 Leading/trailing whitespace on the entire value is trimmed', () => {
+    const result = parse('equity= AAPL,MSFT ');
+    expect(result).toEqual({ ok: true, portfolios: [['AAPL', 'MSFT']] });
+  });
+});
+
+// ─── §4. Deduplication ───────────────────────────────────────────────────────
+
+describe('§4 Deduplication', () => {
+  it('4.1 Exact duplicate tickers within a portfolio are rejected', () => {
+    const result = parse('equity=AAPL,MSFT,AAPL');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('Duplicate ticker: AAPL');
+    }
+  });
+
+  it('4.2 Case-insensitive duplicates within a portfolio are rejected', () => {
+    const result = parse('equity=AAPL,aapl');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('Duplicate ticker: AAPL');
+    }
+  });
+
+  it('4.3 Duplicates detected after normalization', () => {
+    const result = parse('equity=msft, Msft');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('Duplicate ticker: MSFT');
+    }
+  });
+
+  it('4.4 Same ticker allowed across different portfolios', () => {
+    const result = parse('equity=AAPL,MSFT&equity=AAPL,GOOG');
+    expect(result).toEqual({
+      ok: true,
+      portfolios: [
+        ['AAPL', 'MSFT'],
+        ['AAPL', 'GOOG'],
+      ],
+    });
+  });
+});
+
+// ─── §5. Max Tickers Limit ──────────────────────────────────────────────────
+
+describe('§5 Max Tickers Limit', () => {
+  it('5.1 At the maximum (20 tickers)', () => {
+    const tickers = 'A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T';
+    const result = parse(`equity=${tickers}`);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.portfolios[0]).toHaveLength(20);
+      expect(result.portfolios[0]).toEqual(['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T']);
+    }
+  });
+
+  it('5.2 Exceeding the maximum', () => {
+    const tickers = 'A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U';
+    const result = parse(`equity=${tickers}`);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('Too many tickers in portfolio 1: 21 exceeds maximum of 20');
+    }
+  });
+});
+
+// ─── §6. Empty and Missing Input ─────────────────────────────────────────────
+
+describe('§6 Empty and Missing Input', () => {
+  it('6.1 Missing equity parameter entirely', () => {
+    const result = parse('');
+    expect(result).toEqual({ ok: true, portfolios: [] });
+  });
+
+  it('6.2 Empty equity value', () => {
+    const result = parse('equity=');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('Empty equity parameter');
+    }
+  });
+
+  it('6.3 Empty token from leading comma', () => {
+    const result = parse('equity=,AAPL');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('Empty ticker at position 1');
+    }
+  });
+
+  it('6.4 Empty token from trailing comma', () => {
+    const result = parse('equity=AAPL,');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('Empty ticker at position 2');
+    }
+  });
+
+  it('6.5 Empty token from consecutive commas', () => {
+    const result = parse('equity=AAPL,,MSFT');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('Empty ticker at position 2');
+    }
+  });
+
+  it('6.6 Only commas', () => {
+    const result = parse('equity=,,,');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('Empty ticker at position 1');
+    }
+  });
+});
+
+// ─── §7. Reserved Syntax Rejection (`:` and `=` — v2 Weight Syntax) ─────────
+
+describe('§7 Reserved Syntax Rejection', () => {
+  it('7.1 Colon inside a token is rejected', () => {
+    const result = parse('equity=AAPL:0.5');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("Invalid character ':' in ticker 'AAPL:0.5' — colons are reserved for v2 weight syntax");
+    }
+  });
+
+  it('7.2 URL-encoded colon (%3A) inside a token is rejected', () => {
+    // URLSearchParams decodes %3A → :
+    const result = parse('equity=AAPL%3A0.5');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("Invalid character ':' in ticker 'AAPL:0.5' — colons are reserved for v2 weight syntax");
+    }
+  });
+
+  it('7.3 Equals sign inside a token is rejected', () => {
+    const result = parse('equity=AAPL%3D0.5');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("Invalid character '=' in ticker 'AAPL=0.5' — equals signs are reserved");
+    }
+  });
+
+  it('7.3a URL-encoded equals (%3D) inside a token is rejected', () => {
+    const result = parse('equity=AAPL%3D0.5');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("Invalid character '=' in ticker 'AAPL=0.5' — equals signs are reserved");
+    }
+  });
+
+  it('7.4 Colon in one of multiple tokens', () => {
+    const result = parse('equity=AAPL,MSFT:0.3,GOOG');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("Invalid character ':' in ticker 'MSFT:0.3' — colons are reserved for v2 weight syntax");
+    }
+  });
+
+  it('7.5 Semicolon is rejected', () => {
+    const result = parse('equity=AAPL;MSFT');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("Invalid character ';' in ticker 'AAPL;MSFT'");
+    }
+  });
+
+  it('7.6 Pipe is rejected', () => {
+    const result = parse('equity=AAPL|MSFT');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("Invalid character '|' in ticker 'AAPL|MSFT'");
+    }
+  });
+});
+
+// ─── §8. Invalid Ticker Format ───────────────────────────────────────────────
+
+describe('§8 Invalid Ticker Format', () => {
+  it('8.1 Numeric-only ticker is rejected', () => {
+    const result = parse('equity=1234');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("Invalid ticker format: '1234' — must start with a letter");
+    }
+  });
+
+  it('8.2 Ticker with special characters is rejected', () => {
+    const result = parse('equity=AA$PL');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("Invalid character '$' in ticker 'AA$PL'");
+    }
+  });
+
+  it('8.3 Ticker with spaces inside is rejected (after trim)', () => {
+    const result = parse('equity=AA PL');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("Invalid character ' ' in ticker 'AA PL'");
+    }
+  });
+
+  it('8.4 Ticker with hash is rejected', () => {
+    // Note: # in URLs truncates at the fragment, so we use URL-encoded %23
+    const result = parsePortfolios(new URLSearchParams([['equity', 'AAPL#B']]));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("Invalid character '#' in ticker 'AAPL#B'");
+    }
+  });
+
+  it('8.5 Ticker with at-sign is rejected', () => {
+    const result = parse('equity=@AAPL');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("Invalid character '@' in ticker '@AAPL'");
+    }
+  });
+
+  it('8.6 Ticker exceeding max length (10 chars) is rejected', () => {
+    const result = parse('equity=ABCDEFGHIJK');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("Ticker too long: 'ABCDEFGHIJK' exceeds 10 character limit");
+    }
+  });
+
+  it('8.7 Valid ticker with dot (e.g., BRK.B)', () => {
+    const result = parse('equity=BRK.B');
+    expect(result).toEqual({ ok: true, portfolios: [['BRK.B']] });
+  });
+
+  it('8.8 Valid ticker with hyphen (e.g., BF-B)', () => {
+    const result = parse('equity=BF-B');
+    expect(result).toEqual({ ok: true, portfolios: [['BF-B']] });
+  });
+});
+
+// ─── §9. URL Encoding ────────────────────────────────────────────────────────
+
+describe('§9 URL Encoding', () => {
+  it('9.1 URL-encoded comma (%2C) works as separator', () => {
+    // URLSearchParams decodes %2C → ,
+    const result = parse('equity=AAPL%2CMSFT');
+    expect(result).toEqual({ ok: true, portfolios: [['AAPL', 'MSFT']] });
+  });
+
+  it('9.2 URL-encoded space (%20) is trimmed', () => {
+    const result = parse('equity=%20AAPL%20');
+    expect(result).toEqual({ ok: true, portfolios: [['AAPL']] });
+  });
+
+  it('9.3 Plus sign (+) as space is trimmed', () => {
+    const result = parse('equity=+AAPL+');
+    expect(result).toEqual({ ok: true, portfolios: [['AAPL']] });
+  });
+
+  it('9.4 URL-encoded colon (%3A) is rejected (same as literal colon)', () => {
+    const result = parse('equity=MSFT%3A0.5');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("Invalid character ':' in ticker 'MSFT:0.5' — colons are reserved for v2 weight syntax");
+    }
+  });
+});
+
+// ─── §10. Multiple equity Parameters (Multi-Portfolio) ───────────────────────
+
+describe('§10 Multiple equity Parameters (Multi-Portfolio)', () => {
+  it('10.1 Two portfolios', () => {
+    const result = parse('equity=AAPL,MSFT&equity=GOOG,TSLA,NVDA');
+    expect(result).toEqual({
+      ok: true,
+      portfolios: [
+        ['AAPL', 'MSFT'],
+        ['GOOG', 'TSLA', 'NVDA'],
+      ],
+    });
+  });
+
+  it('10.2 At the maximum (5 portfolios)', () => {
+    const result = parse('equity=AAPL&equity=MSFT&equity=GOOG&equity=TSLA&equity=NVDA');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.portfolios).toHaveLength(5);
+      expect(result.portfolios).toEqual([['AAPL'], ['MSFT'], ['GOOG'], ['TSLA'], ['NVDA']]);
+    }
+  });
+
+  it('10.3 Exceeding the maximum number of portfolios', () => {
+    const result = parse('equity=A&equity=B&equity=C&equity=D&equity=E&equity=F');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('Too many portfolios: 6 exceeds maximum of 5');
+    }
+  });
+
+  it('10.4 Error in second portfolio does not affect first', () => {
+    const result = parse('equity=AAPL,MSFT&equity=GOOG,,TSLA');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('Empty ticker at position 2 in portfolio 2');
+    }
+  });
+
+  it('10.5 Empty second equity param', () => {
+    const result = parse('equity=AAPL&equity=');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('Empty equity parameter in portfolio 2');
+    }
+  });
+});
+
+// ─── §11. Unrecognized Query Parameters ──────────────────────────────────────
+
+describe('§11 Unrecognized Query Parameters', () => {
+  it('11.1 Unknown parameters are silently ignored', () => {
+    const result = parse('equity=AAPL&foo=bar');
+    expect(result).toEqual({ ok: true, portfolios: [['AAPL']] });
+  });
+});
+
+// ─── §12. Combined Edge Cases ────────────────────────────────────────────────
+
+describe('§12 Combined Edge Cases', () => {
+  it('12.1 Normalization + dedup detection', () => {
+    const result = parse('equity= aapl , AAPL ');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('Duplicate ticker: AAPL');
+    }
+  });
+
+  it('12.2 Trailing comma + max limit', () => {
+    const tickers = 'A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,';
+    const result = parse(`equity=${tickers}`);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('Empty ticker at position 21');
+    }
+  });
+
+  it('12.3 Reserved char in dedup context', () => {
+    const result = parse('equity=AAPL:0.5,AAPL');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("Invalid character ':' in ticker 'AAPL:0.5' — colons are reserved for v2 weight syntax");
+    }
+  });
+
+  it('12.4 Multi-portfolio with per-portfolio error', () => {
+    const result = parse('equity=AAPL,MSFT&equity=GOOG:0.5');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("Invalid character ':' in ticker 'GOOG:0.5' — colons are reserved for v2 weight syntax");
+    }
+  });
+});
+
+// ─── §13. Error Behavior Contract ────────────────────────────────────────────
+
+describe('§13 Error Behavior Contract', () => {
+  it('13.1 First error wins (fail-fast)', () => {
+    // Input has empty token at position 1, colon at position 2, duplicate at position 3
+    // Only the first error (empty token) should be returned
+    const result = parse('equity=,AAPL:0.5,AAPL');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('Empty ticker at position 1');
+    }
+  });
+
+  it('13.2 Error includes enough context to debug', () => {
+    // Verify various error types include the offending value or position
+    const cases = [
+      { query: 'equity=AAPL,,MSFT', should_include: 'position 2' },
+      { query: 'equity=AA$PL', should_include: "ticker 'AA$PL'" },
+      { query: 'equity=AAPL:0.5', should_include: "ticker 'AAPL:0.5'" },
+      { query: 'equity=AAPL,AAPL', should_include: 'AAPL' },
+    ];
+    for (const { query, should_include } of cases) {
+      const result = parse(query);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toContain(should_include);
+      }
+    }
+  });
+
+  it('13.3 Multi-portfolio errors include the portfolio number', () => {
+    const result = parse('equity=AAPL&equity=GOOG,,TSLA');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('in portfolio 2');
+    }
+  });
+});
+
+// ─── §14. v2 Weight Syntax — Explicitly Reserved (rejection coverage) ────────
+
+describe('§14 v2 Weight Syntax — Explicitly Reserved', () => {
+  it('AAPL:0.5 is rejected', () => {
+    const result = parse('equity=AAPL:0.5');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('colons are reserved for v2 weight syntax');
+    }
+  });
+
+  it('AAPL%3A0.5 (URL-encoded) is rejected', () => {
+    const result = parse('equity=AAPL%3A0.5');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('colons are reserved for v2 weight syntax');
+    }
+  });
+
+  it('AAPL:60,MSFT:40 is rejected', () => {
+    const result = parse('equity=AAPL:60,MSFT:40');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('colons are reserved for v2 weight syntax');
+    }
+  });
+
+  it('AAPL=0.5 is rejected', () => {
+    const result = parse('equity=AAPL%3D0.5');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('equals signs are reserved');
+    }
+  });
+
+  it('AAPL%3D0.5 (URL-encoded) is rejected', () => {
+    const result = parse('equity=AAPL%3D0.5');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('equals signs are reserved');
+    }
+  });
+});
+
+// ─── Exported Constants ──────────────────────────────────────────────────────
+
+describe('Exported constants match SCENARIOS.md', () => {
+  it('MAX_PORTFOLIOS is 5', () => {
+    expect(MAX_PORTFOLIOS).toBe(5);
+  });
+
+  it('MAX_TICKERS_PER_PORTFOLIO is 20', () => {
+    expect(MAX_TICKERS_PER_PORTFOLIO).toBe(20);
+  });
+
+  it('MAX_TICKER_LENGTH is 10', () => {
+    expect(MAX_TICKER_LENGTH).toBe(10);
+  });
+});

--- a/common/parser.ts
+++ b/common/parser.ts
@@ -1,0 +1,162 @@
+// v1 Query Parser — equity= URL parameter
+// Contract defined in SCENARIOS.md sections 1–13
+// See LIL-INTDEV-AGENTS.md §3 for architecture context
+
+export const MAX_PORTFOLIOS = 5;
+export const MAX_TICKERS_PER_PORTFOLIO = 20;
+export const MAX_TICKER_LENGTH = 10;
+
+const VALID_TICKER_CHARS = /^[A-Za-z0-9.\-]+$/;
+const STARTS_WITH_LETTER = /^[A-Za-z]/;
+const RESERVED_COLON = /:/;
+const RESERVED_EQUALS = /=/;
+
+export interface ParseSuccess {
+  ok: true;
+  portfolios: string[][];
+}
+
+export interface ParseError {
+  ok: false;
+  error: string;
+}
+
+export type ParseResult = ParseSuccess | ParseError;
+
+/**
+ * Parse the `equity` query parameter(s) from a URL search string.
+ *
+ * Follows the validation pipeline order defined in SCENARIOS.md:
+ * 1. Portfolio count check
+ * 2. Empty value check
+ * 3. Split on comma
+ * 4. Per-token validation (trim, empty, reserved chars, illegal chars, starts-with-letter, max-length, uppercase, dedup)
+ * 5. Ticker count check
+ */
+export function parsePortfolios(searchParams: URLSearchParams): ParseResult {
+  const equityValues = searchParams.getAll('equity');
+
+  // No equity param at all → empty portfolios, no error (scenario 6.1)
+  if (equityValues.length === 0) {
+    return { ok: true, portfolios: [] };
+  }
+
+  // Step 1: Portfolio count check (scenario 10.3)
+  if (equityValues.length > MAX_PORTFOLIOS) {
+    return {
+      ok: false,
+      error: `Too many portfolios: ${equityValues.length} exceeds maximum of ${MAX_PORTFOLIOS}`,
+    };
+  }
+
+  const portfolios: string[][] = [];
+  const isMulti = equityValues.length > 1;
+
+  for (let pIdx = 0; pIdx < equityValues.length; pIdx++) {
+    const raw = equityValues[pIdx];
+    const portfolioNum = pIdx + 1;
+    const suffix = isMulti ? ` in portfolio ${portfolioNum}` : '';
+
+    // Step 2: Empty value check (scenario 6.2, 10.5)
+    if (raw === '') {
+      return {
+        ok: false,
+        error: `Empty equity parameter${suffix}`,
+      };
+    }
+
+    // Step 3: Split on comma
+    const tokens = raw.split(',');
+
+    // Step 5 (checked early before processing tokens): Ticker count (scenario 5.2)
+    // Note: we check after per-token validation per the pipeline order,
+    // but empty tokens would fail first anyway. We do the actual count check after token processing.
+
+    const seen = new Set<string>();
+    const tickers: string[] = [];
+
+    for (let tIdx = 0; tIdx < tokens.length; tIdx++) {
+      const position = tIdx + 1;
+      const posSuffix = isMulti ? ` in portfolio ${portfolioNum}` : '';
+
+      // Step 4a: Trim whitespace
+      const trimmed = tokens[tIdx].trim();
+
+      // Step 4b: Empty token check (scenarios 3.2, 6.3, 6.4, 6.5, 6.6)
+      if (trimmed === '') {
+        return {
+          ok: false,
+          error: `Empty ticker at position ${position}${posSuffix}`,
+        };
+      }
+
+      // Step 4c: Reserved characters — colon (scenarios 7.1, 7.2, 7.4)
+      if (RESERVED_COLON.test(trimmed)) {
+        return {
+          ok: false,
+          error: `Invalid character ':' in ticker '${trimmed}' — colons are reserved for v2 weight syntax`,
+        };
+      }
+
+      // Step 4c: Reserved characters — equals (scenario 7.3)
+      if (RESERVED_EQUALS.test(trimmed)) {
+        return {
+          ok: false,
+          error: `Invalid character '=' in ticker '${trimmed}' — equals signs are reserved`,
+        };
+      }
+
+      // Step 4d: Illegal characters (scenarios 7.5, 7.6, 8.2, 8.3, 8.4, 8.5)
+      if (!VALID_TICKER_CHARS.test(trimmed)) {
+        // Find the first illegal character for the error message
+        const illegalChar = trimmed.split('').find((ch) => !ch.match(/[A-Za-z0-9.\-]/));
+        return {
+          ok: false,
+          error: `Invalid character '${illegalChar}' in ticker '${trimmed}'`,
+        };
+      }
+
+      // Step 4e: Must start with letter (scenario 8.1)
+      if (!STARTS_WITH_LETTER.test(trimmed)) {
+        return {
+          ok: false,
+          error: `Invalid ticker format: '${trimmed}' — must start with a letter`,
+        };
+      }
+
+      // Step 4f: Max length (scenario 8.6)
+      if (trimmed.length > MAX_TICKER_LENGTH) {
+        return {
+          ok: false,
+          error: `Ticker too long: '${trimmed}' exceeds ${MAX_TICKER_LENGTH} character limit`,
+        };
+      }
+
+      // Step 4g: Uppercase normalization (scenarios 2.1, 2.2)
+      const upper = trimmed.toUpperCase();
+
+      // Step 4h: Duplicate check within this portfolio (scenarios 4.1, 4.2, 4.3)
+      if (seen.has(upper)) {
+        return {
+          ok: false,
+          error: `Duplicate ticker: ${upper}${posSuffix}`,
+        };
+      }
+
+      seen.add(upper);
+      tickers.push(upper);
+    }
+
+    // Step 5: Ticker count check (scenario 5.2)
+    if (tickers.length > MAX_TICKERS_PER_PORTFOLIO) {
+      return {
+        ok: false,
+        error: `Too many tickers in portfolio ${portfolioNum}: ${tickers.length} exceeds maximum of ${MAX_TICKERS_PER_PORTFOLIO}`,
+      };
+    }
+
+    portfolios.push(tickers);
+  }
+
+  return { ok: true, portfolios };
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "dev": "next -p 10000",
     "build": "next build",
     "start": "PORT=10000 next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "next": "16.1.3",
@@ -21,7 +23,7 @@
     "@types/node": "^25.0.3",
     "@types/react": "^19.2.7",
     "ts-node": "^10.9.2",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.18"
   }
 }
-

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Task 4 from plan #29

**Plan:** Plan: v1 auth-free portfolio-compare MVP (strict parser + scenarios + agent docs), with v2 weights reserved
**Goal:** Ship an auth-free v1 portfolio-vs-benchmark compare app with a strict, test-backed query contract (equal-weight only), plus clear agent/scenario documentation; keep v2 weights explicitly reserved and specified for follow-up.

### Changes
4 files changed, 713 insertions(+), 3 deletions(-)

**Files changed (4):**
- `common/parser.test.ts`
- `common/parser.ts`
- `package.json`
- `vitest.config.ts`

**Tests:** Passed

---
Part of #29