### PR TITLE
task(3): Implement strict v1 query parser (portfolios) with clear error messages

### DIFF
--- a/app/api/compare/validate/route.test.ts
+++ b/app/api/compare/validate/route.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { GET } from './route';
+import { NextRequest } from 'next/server';
+
+function makeRequest(query: string): NextRequest {
+  return new NextRequest(`http://localhost:10000/api/compare/validate?${query}`);
+}
+
+describe('/api/compare/validate', () => {
+  it('returns 200 with parsed portfolios for valid input', async () => {
+    const res = await GET(makeRequest('equity=AAPL,MSFT'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.portfolios).toEqual([['AAPL', 'MSFT']]);
+  });
+
+  it('returns 200 for multiple portfolios', async () => {
+    const res = await GET(makeRequest('equity=AAPL,MSFT&equity=GOOG,TSLA'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.portfolios).toEqual([['AAPL', 'MSFT'], ['GOOG', 'TSLA']]);
+  });
+
+  it('returns 400 when equity param is missing', async () => {
+    const res = await GET(makeRequest(''));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('equity param is required');
+  });
+
+  it('returns 400 for empty equity value', async () => {
+    const res = await GET(makeRequest('equity='));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Empty equity parameter');
+  });
+
+  it('returns 400 for colon (v2 reserved syntax)', async () => {
+    const res = await GET(makeRequest('equity=AAPL:0.5'));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('colons are reserved for v2 weight syntax');
+  });
+
+  it('returns 400 for duplicate tickers', async () => {
+    const res = await GET(makeRequest('equity=AAPL,aapl'));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Duplicate ticker: AAPL');
+  });
+
+  it('returns 400 for too many portfolios', async () => {
+    const res = await GET(makeRequest('equity=A&equity=B&equity=C&equity=D&equity=E&equity=F'));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Too many portfolios: 6 exceeds maximum of 5');
+  });
+
+  it('returns 400 for invalid ticker characters', async () => {
+    const res = await GET(makeRequest('equity=AA$PL'));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Invalid character '$'");
+  });
+
+  it('normalizes tickers to uppercase', async () => {
+    const res = await GET(makeRequest('equity=aapl,msft'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.portfolios).toEqual([['AAPL', 'MSFT']]);
+  });
+});

--- a/app/api/compare/validate/route.ts
+++ b/app/api/compare/validate/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { parsePortfolios } from '@common/parser';
+
+/**
+ * GET /api/compare/validate?equity=AAPL,MSFT&equity=GOOG,TSLA
+ *
+ * Validates the user-facing `equity=` query params using the strict v1 parser.
+ * Returns 400 with an actionable error message on invalid input.
+ * Returns 200 with parsed portfolios on success.
+ *
+ * This endpoint enables server-side validation of the compare URL before
+ * fetching market data, and supports SSR error rendering.
+ */
+export async function GET(request: NextRequest) {
+  const result = parsePortfolios(request.nextUrl.searchParams);
+
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: 400 });
+  }
+
+  if (result.portfolios.length === 0) {
+    return NextResponse.json({ error: 'equity param is required' }, { status: 400 });
+  }
+
+  return NextResponse.json({ portfolios: result.portfolios });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,19 @@
+import path from 'path';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@root': path.resolve(__dirname),
+      '@common': path.resolve(__dirname, 'common'),
+      '@components': path.resolve(__dirname, 'components'),
+      '@system': path.resolve(__dirname, 'system'),
+      '@demos': path.resolve(__dirname, 'demos'),
+      '@data': path.resolve(__dirname, 'data'),
+      '@pages': path.resolve(__dirname, 'pages'),
+      '@modules': path.resolve(__dirname, 'modules'),
+    },
+  },
   test: {
     include: ['**/*.test.ts'],
   },


### PR DESCRIPTION
## Task 3 from plan #29

**Plan:** Plan: v1 auth-free portfolio-compare MVP (strict parser + scenarios + agent docs), with v2 weights reserved
**Goal:** Ship an auth-free v1 portfolio-vs-benchmark compare app with a strict, test-backed query contract (equal-weight only), plus clear agent/scenario documentation; keep v2 weights explicitly reserved and specified for follow-up.

### Changes
3 files changed, 112 insertions(+)

**Files changed (3):**
- `app/api/compare/validate/route.test.ts`
- `app/api/compare/validate/route.ts`
- `vitest.config.ts`

**Tests:** Passed

---
Part of #29