### PR TITLE
task(6): Document v2 weights contract (no implementation): reserved `:` syntax and future acceptance criteria

### DIFF
--- a/LIL-INTDEV-AGENTS.md
+++ b/LIL-INTDEV-AGENTS.md
@@ -61,7 +61,7 @@ These constraints define v1 and **must not be violated** without a new version b
 | --- | --- | --- |
 | **Auth-free** | The app works without login, API keys, or any auth wall for the end user. Server-side keys for data providers are invisible to visitors. | Issue [#5](https://github.com/internet-development/www-lil-intdev-portfolio-compare/issues/5), scenario A16 |
 | **Equal-weight only** | Every equity in `equity=` gets weight 1/N. There is no syntax for custom weights in v1. | Issue [#5](https://github.com/internet-development/www-lil-intdev-portfolio-compare/issues/5) |
-| **`:` is reserved for v2 weight syntax** | The colon character (`:`) inside a ticker token (e.g. `AAPL:0.5`) must be **rejected** in v1 with a clear forward-compat message. **Do not silently accept, strip, or ignore colons.** This reserves the syntax for the v2 weighted-portfolio feature. See SCENARIOS.md §7 and §14. | Issue [#10](https://github.com/internet-development/www-lil-intdev-portfolio-compare/issues/10), scenario 7.1 |
+| **`:` is reserved for v2 weight syntax** | The colon character (`:`) inside a ticker token (e.g. `AAPL:0.5`) must be **rejected** in v1 with a clear forward-compat message. **Do not silently accept, strip, or ignore colons.** This reserves the syntax for the v2 weighted-portfolio feature. See SCENARIOS.md §7 and §14, and [`docs/weights-v2.md`](./docs/weights-v2.md) for the full v2 contract. | Issue [#10](https://github.com/internet-development/www-lil-intdev-portfolio-compare/issues/10), scenario 7.1 |
 | **`=` is also reserved** | Same treatment as `:`. Reject with a clear message, never silently accept. | Scenario 7.3 |
 
 ---
@@ -274,6 +274,21 @@ Each SOUL (agent) owns a vertical slice. Coordinate through this doc and SCENARI
 3. Use existing SRCL primitives (Card, Grid, Row, Table, etc.) for layout.
 4. Wire it into `app/page.tsx` or the relevant page.
 5. Ensure mobile responsiveness (scenario A23) — viewport < 768px must remain usable.
+
+---
+
+## 11.1 v2 Weights — Reserved, Not Implemented
+
+The v2 weighted-portfolio feature is **fully specified but not yet shipped**. Key references:
+
+| Document | What it covers |
+| --- | --- |
+| [`docs/weights-v2.md`](./docs/weights-v2.md) | Full v2 contract: token grammar, validation rules, error messages, rebalancing semantics, open questions |
+| [`SCENARIOS.md` §14](./SCENARIOS.md) | Summary of v2 decisions + v1 rejection table |
+| [`SCENARIOS.md` §7](./SCENARIOS.md) | v1 tests that enforce `:` and `=` rejection |
+| [`common/parser.ts`](./common/parser.ts) | v1 implementation — rejects `:` with v2-reserved message |
+
+**For agents:** Do not implement v2 weight parsing. The v1 parser must continue to reject `:` with the message `"colons are reserved for v2 weight syntax"`. When v2 implementation begins, start from `docs/weights-v2.md` as the contract.
 
 ---
 

--- a/SCENARIOS.md
+++ b/SCENARIOS.md
@@ -580,11 +580,20 @@ In v1, all of the following are **explicitly rejected**:
 | `AAPL%3D0.5`          | URL-encoded equals — same rule applies after decoding        |
 
 **v2 design notes (out of scope for v1 implementation):**
-- Weight values will follow the colon: `TICKER:WEIGHT`
-- Weights are decimal fractions (e.g., `0.6`) or integer percents (e.g., `60`)
-- If all tickers have weights, they must sum to 1.0 (or 100%)
-- If no ticker has a weight, v2 falls back to v1 equal-weight behavior
-- Mixed weighted/unweighted tickers within a portfolio are undefined
+
+> The full v2 weights contract — including token grammar, validation rules, error messages, and rebalancing semantics — is specified in [`docs/weights-v2.md`](./docs/weights-v2.md). The summary below captures the key decisions.
+
+- **Syntax:** Weight values follow the colon: `TICKER:WEIGHT` (e.g., `AAPL:0.6` or `AAPL:60%`)
+- **Format:** Both decimal fractions (`0.6`) and explicit percent (`60%`) are accepted. Bare integers > 1 without `%` are rejected as ambiguous (e.g., `AAPL:60` → error; use `AAPL:60%` or `AAPL:0.6`)
+- **Sum constraint:** All weights in a portfolio must sum to 1.0 (±0.01 tolerance for rounding)
+- **No negatives:** Negative weights (short positions) are rejected
+- **No zeros:** Zero-weight tickers are rejected — remove the ticker instead
+- **No duplicates:** Same as v1 — duplicate tickers within a portfolio are rejected
+- **No mixing:** Mixed weighted/unweighted tickers within a portfolio are rejected (all or nothing)
+- **Equal-weight fallback:** If no ticker has a weight, v2 falls back to v1 equal-weight (1/N) behavior — full backward compatibility
+- **Per-portfolio independence:** One portfolio can be weighted while another is equal-weight
+- **Rebalancing:** Not in v2. Weights represent initial allocation; portfolio drifts with price changes (buy-and-hold). Rebalancing is deferred to v3 with a `rebalance=` param
+- **Precision:** Max 4 decimal places per weight
 
 ---
 

--- a/docs/weights-v2.md
+++ b/docs/weights-v2.md
@@ -1,0 +1,256 @@
+# v2 Weights Contract — Reserved, Not Yet Shipped
+
+> **Status: v2 / NOT IMPLEMENTED.** This document specifies the future weighted-portfolio feature. Nothing here is active in v1. The v1 parser **rejects** all weight syntax with a clear error (see [SCENARIOS.md §7](../SCENARIOS.md) and [parser.ts](../common/parser.ts)).
+
+Origin: [Issue #10](https://github.com/internet-development/www-lil-intdev-portfolio-compare/issues/10)
+
+---
+
+## 1. URL Syntax
+
+Weights use the **colon** (`:`) separator already reserved in v1:
+
+```
+?equity=AAPL:0.6,MSFT:0.4
+?equity=AAPL:60,MSFT:40            ← percent form
+?equity=AAPL,MSFT                   ← no weights → equal-weight (1/N), same as v1
+```
+
+Multiple portfolios follow the same `equity=…&equity=…` pattern:
+
+```
+?equity=AAPL:0.6,MSFT:0.4&equity=GOOG:0.5,TSLA:0.5&benchmark=gold
+```
+
+### 1.1 Token grammar
+
+```
+token       = TICKER
+            | TICKER ":" WEIGHT
+
+TICKER      = [A-Za-z][A-Za-z0-9.\-]{0,9}      ← same as v1 (max 10 chars, starts with letter)
+WEIGHT      = DECIMAL | PERCENT
+DECIMAL     = [0-9]+ "." [0-9]+                  ← e.g. 0.6, 0.25, 1.0
+            | "0"                                 ← explicit zero (rejected — see §3.4)
+            | "1"                                 ← shorthand for 1.0 (100%)
+PERCENT     = [0-9]+ "%"                          ← e.g. 60%, 25%, 100%
+```
+
+---
+
+## 2. Weight Format — Decisions
+
+### 2.1 Both decimals and percents are accepted
+
+The parser accepts **both** decimal fractions and integer-percent notation:
+
+| Input | Interpreted as |
+| --- | --- |
+| `AAPL:0.6` | 60% weight |
+| `AAPL:60%` | 60% weight |
+| `AAPL:0.25` | 25% weight |
+| `AAPL:25%` | 25% weight |
+| `AAPL:1` | 100% weight (single-stock portfolio) |
+| `AAPL:1.0` | 100% weight |
+| `AAPL:100%` | 100% weight |
+
+**Disambiguation rule:** A bare integer without `%` is treated as a decimal fraction if ≤ 1, and rejected as ambiguous if > 1 and missing `%`. This avoids confusion between `60` (is it 60% or 0.60?).
+
+| Input | Interpretation |
+| --- | --- |
+| `AAPL:0.6` | Decimal → 60% |
+| `AAPL:1` | Decimal → 100% |
+| `AAPL:60` | **Rejected** — ambiguous. Use `60%` or `0.6` |
+| `AAPL:60%` | Percent → 60% |
+
+### 2.2 Internal representation
+
+Weights are stored internally as decimal fractions (`0.0` to `1.0`). Percent inputs are divided by 100 before storage.
+
+---
+
+## 3. Validation Rules
+
+All weight validation occurs **after** the existing v1 ticker validation passes (reserved-char check is replaced by weight parsing in v2).
+
+### 3.1 Weights must sum to 1.0 (tolerance: ±0.01)
+
+```
+Given  ?equity=AAPL:0.6,MSFT:0.4
+Then   sum = 1.0 → accepted
+
+Given  ?equity=AAPL:0.6,MSFT:0.3
+Then   sum = 0.9 → rejected
+Error: "Portfolio weights sum to 0.9, must equal 1.0"
+
+Given  ?equity=AAPL:0.601,MSFT:0.4
+Then   sum = 1.001 → accepted (within ±0.01 tolerance)
+```
+
+Tolerance of ±0.01 accounts for user rounding. Internally, weights are re-normalized to sum to exactly 1.0 after tolerance check.
+
+### 3.2 No negative weights
+
+```
+Given  ?equity=AAPL:-0.5,MSFT:1.5
+Then   rejected
+Error: "Negative weight for ticker 'AAPL': -0.5 — negative weights (short positions) are not supported"
+```
+
+Negative weights imply short-selling, which is out of scope.
+
+### 3.3 No zero weights
+
+```
+Given  ?equity=AAPL:0,MSFT:1.0
+Then   rejected
+Error: "Zero weight for ticker 'AAPL' — remove tickers you don't want in the portfolio"
+```
+
+A zero-weighted ticker has no effect on portfolio performance and is misleading.
+
+### 3.4 No duplicate tickers (same as v1)
+
+```
+Given  ?equity=AAPL:0.5,AAPL:0.5
+Then   rejected
+Error: "Duplicate ticker: AAPL"
+```
+
+This is unchanged from v1 — duplicates are rejected post-normalization.
+
+### 3.5 Mixed weighted/unweighted tokens are rejected
+
+```
+Given  ?equity=AAPL:0.6,MSFT,GOOG:0.2
+Then   rejected
+Error: "Mixed weighted and unweighted tickers — either all tickers must have weights or none"
+```
+
+Mixing `:` and bare tickers within a single portfolio is not allowed. Each portfolio is either fully weighted or fully equal-weight.
+
+### 3.6 All-unweighted falls back to v1 equal-weight
+
+```
+Given  ?equity=AAPL,MSFT,GOOG
+Then   each ticker gets weight 1/3
+```
+
+This preserves full backward compatibility with v1 URLs.
+
+### 3.7 Per-portfolio independence
+
+Weight rules apply independently per portfolio. One portfolio can be weighted while another is equal-weight:
+
+```
+Given  ?equity=AAPL:0.6,MSFT:0.4&equity=GOOG,TSLA
+Then   portfolio 1: AAPL=0.6, MSFT=0.4
+  And  portfolio 2: GOOG=0.5, TSLA=0.5 (equal-weight)
+```
+
+### 3.8 Weight precision
+
+Weights are parsed with up to 4 decimal places. More than 4 decimal places are rejected:
+
+```
+Given  ?equity=AAPL:0.12345
+Then   rejected
+Error: "Weight precision too high for 'AAPL': max 4 decimal places"
+```
+
+---
+
+## 4. Ambiguous integer rejection — examples
+
+| Input | Result | Reason |
+| --- | --- | --- |
+| `AAPL:0` | Rejected | Zero weight (§3.3) |
+| `AAPL:1` | Accepted as 1.0 (100%) | Unambiguous — the only integer ≤ 1 that makes sense |
+| `AAPL:2` | Rejected | Ambiguous — is it 200% or 2%? Use `2%` or `0.02` |
+| `AAPL:50` | Rejected | Ambiguous — use `50%` or `0.5` |
+| `AAPL:50%` | Accepted as 0.5 | Percent form is explicit |
+| `AAPL:0.5` | Accepted as 0.5 | Decimal form is explicit |
+
+---
+
+## 5. Rebalancing Semantics
+
+> **Decision: No rebalancing in v2 MVP.**
+
+v2 weights represent the **initial allocation** at the start of the time range. As prices change, actual portfolio weights drift from the initial allocation. The chart shows this natural drift — it does **not** simulate periodic rebalancing.
+
+### 5.1 Why no rebalancing for v2 MVP
+
+- Rebalancing introduces complexity: frequency (daily, monthly, quarterly?), transaction costs, tax implications
+- The primary use case is "how would this allocation have performed?" — buy-and-hold answers this simply
+- Rebalancing can be added as a v3 feature with an explicit `rebalance=monthly` param
+
+### 5.2 Future rebalancing (v3, not v2)
+
+If introduced later, rebalancing would use a new query param:
+
+```
+?equity=AAPL:0.6,MSFT:0.4&rebalance=monthly
+```
+
+Valid rebalance values (tentative): `none` (default), `monthly`, `quarterly`, `annually`.
+
+---
+
+## 6. Error Messages
+
+v2 weight errors follow the same conventions as v1 errors (fail-fast, first error wins, human-readable):
+
+| Condition | Error message |
+| --- | --- |
+| Weights don't sum to 1.0 | `"Portfolio weights sum to {sum}, must equal 1.0"` |
+| Negative weight | `"Negative weight for ticker '{TICKER}': {weight} — negative weights (short positions) are not supported"` |
+| Zero weight | `"Zero weight for ticker '{TICKER}' — remove tickers you don't want in the portfolio"` |
+| Mixed weighted/unweighted | `"Mixed weighted and unweighted tickers — either all tickers must have weights or none"` |
+| Ambiguous integer > 1 | `"Ambiguous weight '{value}' for ticker '{TICKER}' — use '{value}%' for percent or '0.{padded}' for decimal"` |
+| Precision too high | `"Weight precision too high for '{TICKER}': max 4 decimal places"` |
+| Weight > 1.0 (after parsing) | `"Weight exceeds 1.0 for ticker '{TICKER}': {weight}"` |
+| Multi-portfolio error | Same as above with `" in portfolio {N}"` suffix |
+
+---
+
+## 7. v2 Validation Pipeline (extends v1)
+
+The v2 pipeline inserts weight parsing between v1 steps 4c and 4d:
+
+1. **Portfolio count** — same as v1
+2. **Empty value** — same as v1
+3. **Split on comma** — same as v1
+4. **Per-token, left to right:**
+   a. **Trim whitespace** — same as v1
+   b. **Empty token** — same as v1
+   c. **Split on colon** — if token contains `:`, split into `TICKER:WEIGHT`
+   d. **Ticker validation** — illegal chars, starts-with-letter, max-length, uppercase (same as v1, applied to ticker part only)
+   e. **Weight parsing** — parse weight value, check format and range
+   f. **Duplicate check** — same as v1
+5. **Ticker count** — same as v1
+6. **Weight-mode consistency** — all-weighted or all-unweighted per portfolio (§3.5)
+7. **Weight sum** — must equal 1.0 ±0.01 (§3.1)
+
+---
+
+## 8. Backward Compatibility
+
+| v1 URL | v2 behavior |
+| --- | --- |
+| `?equity=AAPL,MSFT` | Works identically — equal-weight 1/N |
+| `?equity=AAPL,MSFT&benchmark=gold` | Works identically |
+| `?equity=AAPL,MSFT&equity=GOOG,TSLA` | Works identically — both portfolios equal-weight |
+
+**All v1 URLs continue to work in v2 with identical behavior.** The weight syntax is purely additive.
+
+---
+
+## 9. Open Questions for v2 Implementation
+
+These items need decisions before v2 implementation begins:
+
+1. **UI for weight display** — How are weights shown in the summary table? Separate column? Inline with ticker?
+2. **Chart legend** — Should the legend show weights (e.g., "AAPL (60%)")?
+3. **URL builder UI** — Should the landing page provide a weight-input form?
+4. **Percent input in URL** — The `%` character is `%25` when URL-encoded. Should we accept both `AAPL:50%25` (encoded) and `AAPL:50%` (literal)? Recommendation: accept the literal form since `%` followed by non-hex chars won't be mis-decoded.


### PR DESCRIPTION
## Task 6 from plan #29

**Plan:** Plan: v1 auth-free portfolio-compare MVP (strict parser + scenarios + agent docs), with v2 weights reserved
**Goal:** Ship an auth-free v1 portfolio-vs-benchmark compare app with a strict, test-backed query contract (equal-weight only), plus clear agent/scenario documentation; keep v2 weights explicitly reserved and specified for follow-up.

### Changes
3 files changed, 286 insertions(+), 6 deletions(-)

**Files changed (3):**
- `LIL-INTDEV-AGENTS.md`
- `SCENARIOS.md`
- `docs/weights-v2.md`

**Tests:** Passed

---
Part of #29