### PR TITLE
task(7): Sanity-check end-to-end slice: parse → fetch → compute → render; update docs accordingly

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,26 @@ Benchmark names are case-insensitive. Combine multiple with pipe: `benchmark=gol
 - **Benchmark spot prices.** Gold and ETH use spot prices in USD. USD benchmark is a flat 0% return line representing cash.
 - **No currency conversion.** All values are in USD. Non-USD-denominated equities use their USD-listed price.
 
+## Try It
+
+After starting the dev server, paste this URL in your browser to verify the end-to-end flow:
+
+```
+http://localhost:10000/?equity=AAPL,MSFT&benchmark=gold&range=1y
+```
+
+**What you should see (v1 current state):** The page parses the URL, validates the query, and displays a portfolio summary card showing each ticker with its equal weight (50.0% each), the benchmark (GOLD), and the range (1y). Invalid queries show an inline error banner. Chart and data-fetching visualization are not yet wired into the page — the API routes (`/api/market-data`, `/api/benchmark`) work independently and return JSON.
+
+**More examples to try:**
+
+| URL | What it tests |
+| --- | --- |
+| `http://localhost:10000/?equity=AAPL,MSFT&benchmark=gold&range=1y` | Two equities vs gold, 1-year |
+| `http://localhost:10000/?equity=TSMC,AAPL,MSFT&benchmark=gold\|eth\|usd` | Three equities vs all benchmarks |
+| `http://localhost:10000/?equity=AAPL,MSFT&equity=GOOG,TSLA&benchmark=gold` | Multi-portfolio comparison |
+| `http://localhost:10000/?equity=AAPL:0.5` | Reserved v2 syntax — should show error |
+| `http://localhost:10000/` | Landing state — empty, shows example URL |
+
 ## Setup
 
 ```sh
@@ -131,6 +151,15 @@ The app works without a paid API key when using free-tier data providers.
 | UI          | React 19, CSS Modules |
 | Components  | SRCL                  |
 | Hosting     | Vercel                |
+
+## v1 Pipeline Status
+
+| Stage | Status | Notes |
+| --- | --- | --- |
+| **Parse** (URL → validated query) | Done | `common/parser.ts`, `common/query.ts`, `common/portfolio.ts` — 98 unit tests passing |
+| **Fetch** (API routes → market data) | Done | `/api/market-data` and `/api/benchmark` return JSON via Yahoo Finance (free, no key) |
+| **Compute** (normalize + weight) | Done | `common/market-data.ts` normalizes to % change; `common/portfolio.ts` computes 1/N weights |
+| **Render** (chart + summary) | Not started | `app/page.tsx` shows parsed portfolio summary card; chart component not yet created |
 
 ## Contact
 

--- a/SCENARIOS.md
+++ b/SCENARIOS.md
@@ -899,6 +899,45 @@ Then   the chart scales to fit the viewport width
   And  all text remains legible
 ```
 
+## A25. Paste URL and see parsed portfolio (v1 sanity check)
+
+> This is the minimal end-to-end scenario for v1. It verifies the parse → display loop works. Chart rendering (fetch → compute → render) is covered by A1–A5 and will be testable once the Chart component is implemented.
+
+```
+Given  the user pastes http://localhost:10000/?equity=AAPL,MSFT&benchmark=gold&range=1y into the browser
+When   the page loads
+Then   the URL is parsed without error
+  And  a portfolio summary card is displayed showing:
+       - AAPL (50.0%) and MSFT (50.0%) with "equal weight (1/2)" label
+       - Benchmark: GOLD
+       - Range: 1y
+  And  no error banner is displayed
+```
+
+## A26. Paste URL with invalid query and see error
+
+```
+Given  the user pastes http://localhost:10000/?equity=AAPL:0.5 into the browser
+When   the page loads
+Then   an error banner is displayed with the message:
+       "Invalid character ':' in ticker 'AAPL:0.5' — colons are reserved for v2 weight syntax"
+  And  no portfolio summary is displayed
+```
+
+## A27. API routes return market data independently
+
+> Verifies the fetch layer works even though the page doesn't yet wire data into the UI.
+
+```
+Given  the dev server is running on port 10000
+When   a GET request is made to /api/market-data?tickers=AAPL,MSFT&range=1y
+Then   the response is 200 with JSON body { series: [...] }
+  And  each series entry has ticker, points (date/close pairs), and source fields
+When   a GET request is made to /api/benchmark?benchmarks=gold|eth&range=1y
+Then   the response is 200 with JSON body { series: [...] }
+  And  Gold and ETH series are returned with price data
+```
+
 ---
 
 ## Benchmark parameter contract


### PR DESCRIPTION
## Task 7 from plan #29

**Plan:** Plan: v1 auth-free portfolio-compare MVP (strict parser + scenarios + agent docs), with v2 weights reserved
**Goal:** Ship an auth-free v1 portfolio-vs-benchmark compare app with a strict, test-backed query contract (equal-weight only), plus clear agent/scenario documentation; keep v2 weights explicitly reserved and specified for follow-up.

### Changes
3 files changed, 126 insertions(+), 13 deletions(-)

**Files changed (3):**
- `LIL-INTDEV-AGENTS.md`
- `README.md`
- `SCENARIOS.md`

**Tests:** Passed

---
Part of #29