### PR TITLE
task(1): Audit README + docs for relative links; convert to repo-root relative where it improves stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,13 +119,13 @@ http://localhost:10000/?equity=AAPL,MSFT&benchmark=gold&range=1y
 
 ### Quick Verification Checklist
 
-After setup, run through these three checks to confirm the app is working (mirrors [SCENARIOS.md](./SCENARIOS.md)):
+After setup, run through these three checks to confirm the app is working (mirrors [SCENARIOS.md](./SCENARIOS.md#local-verification-checklist)):
 
 - [ ] **Happy path (A25):** Open `http://localhost:10000/?equity=AAPL,MSFT&benchmark=gold&range=1y` — you should see a portfolio summary card and a performance chart with solid lines for AAPL/MSFT and a dashed line for Gold.
 - [ ] **Invalid input (A26):** Open `http://localhost:10000/?equity=AAPL:0.5` — you should see an error banner: *"colons are reserved for v2 weight syntax"*. No chart renders.
 - [ ] **Unit tests:** Run `npm test` — all 98 tests should pass (parser, query, portfolio, validation endpoint).
 
-See [SCENARIOS.md → Local Verification Checklist](./SCENARIOS.md) for the full step-by-step verification procedure.
+See [SCENARIOS.md → Local Verification Checklist](./SCENARIOS.md#local-verification-checklist) for the full step-by-step verification procedure.
 
 ## Setup
 


### PR DESCRIPTION
## Task 1 from plan #84

**Plan:** Follow-up from #83: stabilize README links + refresh canonical docs/scenarios
**Goal:** Address post-merge feedback from #83 by ensuring README links are stable (repo-root relative where appropriate) and the canonical docs/scenarios remain consistent with the current ‘Try it’ path and verification steps.

### Changes
1 file changed, 2 insertions(+), 2 deletions(-)

**Files changed (1):**
- `README.md`

**Tests:** Passed

---
Part of #84