### PR TITLE
task(2): Update/verify canonical docs for the ‘Try it’ path and keep them in sync with README

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,13 +119,13 @@ http://localhost:10000/?equity=AAPL,MSFT&benchmark=gold&range=1y
 
 ### Quick Verification Checklist
 
-After setup, run through these three checks to confirm the app is working (mirrors [SCENARIOS.md](./SCENARIOS.md#local-verification-checklist)):
+After setup, run through these three checks to confirm the app is working. The authoritative checklist lives in [SCENARIOS.md → Local Verification Checklist](./SCENARIOS.md#local-verification-checklist); the items below are a quick summary:
 
 - [ ] **Happy path (A25):** Open `http://localhost:10000/?equity=AAPL,MSFT&benchmark=gold&range=1y` — you should see a portfolio summary card and a performance chart with solid lines for AAPL/MSFT and a dashed line for Gold.
 - [ ] **Invalid input (A26):** Open `http://localhost:10000/?equity=AAPL:0.5` — you should see an error banner: *"colons are reserved for v2 weight syntax"*. No chart renders.
 - [ ] **Unit tests:** Run `npm test` — all 98 tests should pass (parser, query, portfolio, validation endpoint).
 
-See [SCENARIOS.md → Local Verification Checklist](./SCENARIOS.md#local-verification-checklist) for the full step-by-step verification procedure.
+For the full step-by-step verification procedure (API curl tests, error cases, validation endpoint, and all browser scenarios), see [SCENARIOS.md → Local Verification Checklist](./SCENARIOS.md#local-verification-checklist).
 
 ## Setup
 

--- a/SCENARIOS.md
+++ b/SCENARIOS.md
@@ -1351,6 +1351,8 @@ Quick reference for which scenarios are testable today vs. awaiting UI work.
 
 # Local Verification Checklist
 
+> **This is the canonical verification procedure.** [README.md → Quick Verification Checklist](./README.md#quick-verification-checklist) contains a 3-item summary for fast smoke-testing. If the two ever diverge, this checklist is the source of truth.
+
 Run these steps to verify the v1 pipeline end-to-end:
 
 ```sh


### PR DESCRIPTION
## Task 2 from plan #84

**Plan:** Follow-up from #83: stabilize README links + refresh canonical docs/scenarios
**Goal:** Address post-merge feedback from #83 by ensuring README links are stable (repo-root relative where appropriate) and the canonical docs/scenarios remain consistent with the current ‘Try it’ path and verification steps.

### Changes
2 files changed, 4 insertions(+), 2 deletions(-)

**Files changed (2):**
- `README.md`
- `SCENARIOS.md`

**Tests:** Passed

---
Part of #84