### PR TITLE
task(3): Align implementation with contract (minimal code change if needed) so `:` is rejected consistently

### DIFF
--- a/app/api/market-data/route.ts
+++ b/app/api/market-data/route.ts
@@ -67,6 +67,16 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'No valid tickers provided' }, { status: 400 });
   }
 
+  // Reject reserved `:` syntax at the API boundary (v1 contract — #117)
+  for (const t of tickerList) {
+    if (t.includes(':')) {
+      return NextResponse.json(
+        { error: 'Weights (:) are not supported in v1. Use a comma-separated list of tickers like "AAPL,MSFT".' },
+        { status: 400 }
+      );
+    }
+  }
+
   const yahooParams = RANGE_TO_YAHOO[range];
 
   try {


### PR DESCRIPTION
## Task 3 from plan #126

**Plan:** Plan: Enforce v1 strict rejection of `:` weight syntax + keep contracts/docs in sync
**Goal:** Ship an enforceable v1 contract for rejecting `ticker:weight` syntax (reserved for v2) by aligning SCENARIOS + unit tests (and any minimal code changes), and consolidate follow-up memos into canonical docs.

### Changes
1 file changed, 10 insertions(+)

**Files changed (1):**
- `app/api/market-data/route.ts`

**Tests:** Passed

---
Part of #126